### PR TITLE
Update 0100E95004038000.json (Xenoblade 2 max ether crystal fix)

### DIFF
--- a/Configs/0100E95004038000.json
+++ b/Configs/0100E95004038000.json
@@ -35,7 +35,7 @@
 		  "widget" : {
 			"type" : "int",
 			"minValue" : 0,
-			"maxValue" : 99
+			"maxValue" : 99999
 		  }
 		},
 		{


### PR DESCRIPTION
edited line 38, maxValue for ether crystals increased from 99 to 99999 per issue #31